### PR TITLE
Add instructions for hosting a Gatsby site on AWS

### DIFF
--- a/src/data/tutorials.yml
+++ b/src/data/tutorials.yml
@@ -2418,3 +2418,17 @@
     - createPages api
     - templates
     - v1
+
+- title: 'Gatsby on AWS, the right way'
+  link: https://blog.joshwalsh.me/aws-gatsby/
+  format: text
+  language: en
+  date: 2019-01-10
+  authors: 
+    - Joshua Walsh
+  topics:
+    - performance
+    - aws
+    - continuous-integration
+    - cloud
+    - hosting


### PR DESCRIPTION
Includes setting up a CDN, serverside redirects, CI/CD pipeline, multiple environments, etc...